### PR TITLE
Add support for impersonated service account credentials

### DIFF
--- a/docs/authentication/index.md
+++ b/docs/authentication/index.md
@@ -9,6 +9,7 @@ Currently supported credentials and tokens:
 | --- | --- | --- |
 | [Service account](https://cloud.google.com/docs/authentication#service-accounts) (via [compute metadata](https://cloud.google.com/compute/docs/metadata/overview)) | ✅ | ✅ |
 | [User credentials](https://cloud.google.com/docs/authentication/application-default-credentials#personal) | ✅ | ❌ |
+| [Impersonated service account](https://cloud.google.com/iam/docs/impersonating-service-accounts) | ✅ | ❌ |
 | Service account (via private key) | ❌ | ❌ |
 
 ## Getting Started

--- a/zio-gcp-auth/shared/src/main/scala/com/anymindgroup/gcp/auth/Credentials.scala
+++ b/zio-gcp-auth/shared/src/main/scala/com/anymindgroup/gcp/auth/Credentials.scala
@@ -30,13 +30,29 @@ object Credentials {
   // https://cloud.google.com/compute/docs/metadata/predefined-metadata-keys#instance-metadata
   final case class ComputeServiceAccount(email: String) extends Credentials
 
+  // https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken
+  final case class ImpersonatedServiceAccount(
+    serviceAccountImpersonationUrl: String,
+    sourceCredentials: CredentialsKey,
+    delegates: List[String] = List.empty,
+    scopes: List[String] = List("https://www.googleapis.com/auth/cloud-platform"),
+  ) extends Credentials
+
   private enum ApplicationCredentials:
     case authorized_user(refresh_token: String, client_id: String, client_secret: String)
     case service_account(client_email: String, private_key: String)
+    case impersonated_service_account(
+      service_account_impersonation_url: String,
+      source_credentials: ApplicationCredentials,
+      delegates: List[String] = List.empty,
+    )
   private object ApplicationCredentials:
     given JsonValueCodec[ApplicationCredentials] =
       JsonCodecMaker.make:
-        CodecMakerConfig.withRequireDiscriminatorFirst(false).withDiscriminatorFieldName(Some("type"))
+        CodecMakerConfig
+          .withRequireDiscriminatorFirst(false)
+          .withDiscriminatorFieldName(Some("type"))
+          .withAllowRecursiveTypes(true)
 
   private def applicationCredentialsPath: IO[CredentialsException, Option[Path]] =
     ZIO.systemWith { system =>
@@ -76,25 +92,49 @@ object Credentials {
         case _ => ZIO.none
       }
 
-  def applicationCredentials: IO[CredentialsException, Option[CredentialsKey]] = for {
+  private def toCredentials(appCreds: ApplicationCredentials): Either[String, Credentials] =
+    appCreds match {
+      case ApplicationCredentials.authorized_user(refreshToken, clientId, secret) =>
+        Right(Credentials.UserAccount(refreshToken = refreshToken, clientId = clientId, clientSecret = Secret(secret)))
+      case ApplicationCredentials.service_account(email, key) =>
+        Right(Credentials.ServiceAccountKey(email = email, privateKey = Secret(key)))
+      case ApplicationCredentials.impersonated_service_account(url, source, delegates) =>
+        source match {
+          case ApplicationCredentials.authorized_user(refreshToken, clientId, secret) =>
+            Right(
+              Credentials.ImpersonatedServiceAccount(
+                serviceAccountImpersonationUrl = url,
+                sourceCredentials = Credentials.UserAccount(refreshToken, clientId, Secret(secret)),
+                delegates = delegates,
+              )
+            )
+          case ApplicationCredentials.service_account(email, key) =>
+            Right(
+              Credentials.ImpersonatedServiceAccount(
+                serviceAccountImpersonationUrl = url,
+                sourceCredentials = Credentials.ServiceAccountKey(email, Secret(key)),
+                delegates = delegates,
+              )
+            )
+          case _: ApplicationCredentials.impersonated_service_account =>
+            Left("Nested impersonated service account credentials are not supported as source credentials")
+        }
+    }
+
+  def applicationCredentials: IO[CredentialsException, Option[Credentials]] = for {
     path <- applicationCredentialsPath.tapSome { case Some(p) =>
               ZIO.log(s"Attempting to read application credentials from $p")
             }
     creds <- path match
                case Some(p) =>
-                 findApplicationCredentials(p).map:
-                   _.map:
-                     case ApplicationCredentials.authorized_user(refreshToken, clientId, secret) =>
-                       Credentials.UserAccount(
-                         refreshToken = refreshToken,
-                         clientId = clientId,
-                         clientSecret = Secret(secret),
-                       )
-                     case ApplicationCredentials.service_account(email, key) =>
-                       Credentials.ServiceAccountKey(
-                         email = email,
-                         privateKey = Secret(key),
-                       )
+                 findApplicationCredentials(p).flatMap {
+                   case None           => ZIO.none
+                   case Some(appCreds) =>
+                     ZIO
+                       .fromEither(toCredentials(appCreds))
+                       .mapError(msg => CredentialsException.InvalidCredentialsFile(msg))
+                       .map(Some(_))
+                 }
                case None => ZIO.none
   } yield creds
 
@@ -124,7 +164,12 @@ object Credentials {
               ZIO.log(s"Found user credentials with client id ${c.clientId}").as(Some(c))
             case Some(c: Credentials.ServiceAccountKey) =>
               ZIO.log(s"Found service account credentials for ${c.email}").as(Some(c))
-            case None =>
+            case Some(c: Credentials.ImpersonatedServiceAccount) =>
+              ZIO
+                .log(s"Found impersonated service account credentials for ${c.serviceAccountImpersonationUrl}")
+                .as(Some(c))
+            case Some(c) => ZIO.some(c)
+            case None    =>
               ZIO.log(s"No credentials were found.").as(None)
           }
       }
@@ -134,7 +179,10 @@ object Credentials {
           ZIO.log(s"Found user credentials with client id ${c.clientId}").as(Some(c))
         case Some(c: Credentials.ServiceAccountKey) =>
           ZIO.log(s"Found service account credentials for ${c.email}").as(Some(c))
-        case None =>
+        case Some(c: Credentials.ImpersonatedServiceAccount) =>
+          ZIO.log(s"Found impersonated service account credentials for ${c.serviceAccountImpersonationUrl}").as(Some(c))
+        case Some(c) => ZIO.some(c)
+        case None    =>
           ZIO.log(s"No application credentials found.") *>
             computeServiceAccount(backend).tap {
               case Some(Credentials.ComputeServiceAccount(email)) =>

--- a/zio-gcp-auth/shared/src/main/scala/com/anymindgroup/gcp/auth/Credentials.scala
+++ b/zio-gcp-auth/shared/src/main/scala/com/anymindgroup/gcp/auth/Credentials.scala
@@ -36,7 +36,13 @@ object Credentials {
     sourceCredentials: CredentialsKey,
     delegates: List[String] = List.empty,
     scopes: List[String] = List("https://www.googleapis.com/auth/cloud-platform"),
-  ) extends Credentials
+  ) extends Credentials {
+    def serviceAccountEmail: String =
+      serviceAccountImpersonationUrl.split("serviceAccounts/") match {
+        case Array(_, v) => v.split(":").headOption.getOrElse("")
+        case _           => ""
+      }
+  }
 
   private enum ApplicationCredentials:
     case authorized_user(refresh_token: String, client_id: String, client_secret: String)
@@ -166,7 +172,7 @@ object Credentials {
               ZIO.log(s"Found service account credentials for ${c.email}").as(Some(c))
             case Some(c: Credentials.ImpersonatedServiceAccount) =>
               ZIO
-                .log(s"Found impersonated service account credentials for ${c.serviceAccountImpersonationUrl}")
+                .log(s"Found impersonated service account credentials for ${c.serviceAccountEmail}")
                 .as(Some(c))
             case Some(c) => ZIO.some(c)
             case None    =>
@@ -180,7 +186,7 @@ object Credentials {
         case Some(c: Credentials.ServiceAccountKey) =>
           ZIO.log(s"Found service account credentials for ${c.email}").as(Some(c))
         case Some(c: Credentials.ImpersonatedServiceAccount) =>
-          ZIO.log(s"Found impersonated service account credentials for ${c.serviceAccountImpersonationUrl}").as(Some(c))
+          ZIO.log(s"Found impersonated service account credentials for ${c.serviceAccountEmail}").as(Some(c))
         case Some(c) => ZIO.some(c)
         case None    =>
           ZIO.log(s"No application credentials found.") *>

--- a/zio-gcp-auth/shared/src/main/scala/com/anymindgroup/gcp/auth/TokenProvider.scala
+++ b/zio-gcp-auth/shared/src/main/scala/com/anymindgroup/gcp/auth/TokenProvider.scala
@@ -1,7 +1,16 @@
 package com.anymindgroup.gcp.auth
 
+import java.time.Instant
+
 import com.anymindgroup.gcp.ComputeMetadata
-import com.anymindgroup.gcp.auth.Credentials.{ComputeServiceAccount, ServiceAccountKey, UserAccount}
+import com.anymindgroup.gcp.auth.Credentials.{
+  ComputeServiceAccount,
+  ImpersonatedServiceAccount,
+  ServiceAccountKey,
+  UserAccount,
+}
+import com.github.plokhotnyuk.jsoniter_scala.core.*
+import com.github.plokhotnyuk.jsoniter_scala.macros.*
 import sttp.client4.*
 import sttp.model.*
 
@@ -51,6 +60,58 @@ object TokenProvider {
       .response(asStringAlways)
       .mapResponse(AccessToken.fromJsonString(_))
 
+  private case class GenerateAccessTokenResponse(accessToken: String, expireTime: String)
+  private object GenerateAccessTokenResponse:
+    given JsonValueCodec[GenerateAccessTokenResponse] = JsonCodecMaker.make
+
+    def fromString(json: String): Either[Throwable, AccessToken] =
+      try
+        val r          = readFromString[GenerateAccessTokenResponse](json)
+        val expireTime = Instant.parse(r.expireTime)
+        val now        = Instant.now()
+        val expiresIn  = zio.Duration.fromSeconds(math.max(0L, expireTime.getEpochSecond - now.getEpochSecond))
+        Right(AccessToken(r.accessToken, expiresIn))
+      catch case e: Throwable => Left(e)
+
+  private[auth] def generateAccessTokenReq(
+    impersonationUrl: String,
+    sourceToken: String,
+    scopes: List[String],
+    delegates: List[String],
+  ): Request[Either[Throwable, AccessToken]] = {
+    val scopeValues    = scopes.map(s => s""""$s"""").mkString(",")
+    val delegateValues = delegates.map(d => s""""$d"""").mkString(",")
+    basicRequest
+      .post(uri"$impersonationUrl")
+      .header("Authorization", s"Bearer $sourceToken")
+      .body(s"""{"scope": [$scopeValues], "delegates": [$delegateValues]}""")
+      .header(Header.contentType(MediaType.ApplicationJson), onDuplicate = DuplicateHeaderBehavior.Replace)
+      .response(asStringAlways)
+      .mapResponse(GenerateAccessTokenResponse.fromString(_))
+  }
+
+  private def autoRefreshTokenProvider[T <: Token](
+    requestToken: IO[TokenProviderException, TokenReceipt[T]],
+    refreshRetrySchedule: Schedule[Any, Any, Any],
+    refreshAtExpirationPercent: Double,
+  ): ZIO[Scope, TokenProviderException, TokenProvider[T]] = {
+    def refreshTokenJob(ref: Ref[TokenReceipt[T]]) =
+      (for {
+        current   <- ref.get
+        _         <- ZIO.sleep(current.token.expiresInOfPercent(refreshAtExpirationPercent))
+        refreshed <- requestToken.retry(refreshRetrySchedule)
+        _         <- ref.update(_ => refreshed)
+      } yield ()).repeat[Any, Long](Schedule.forever)
+
+    for {
+      token <- requestToken
+      ref   <- zio.Ref.make(token)
+      _     <- refreshTokenJob(ref).forkScoped
+    } yield new TokenProvider[T] {
+      override def token: UIO[TokenReceipt[T]] = ref.get
+    }
+  }
+
   private[auth] def autoRefreshTokenProviderByRequest[T <: Token](
     backend: GenericBackend[Task, Any],
     req: Request[Either[Throwable, T]],
@@ -67,21 +128,7 @@ object TokenProvider {
       _   <- ZIO.log(s"Retrieved new token with expiry in ${token.expiresIn.getSeconds()}s")
     } yield TokenReceipt(token, now)
 
-    def refreshTokenJob(ref: Ref[TokenReceipt[T]]) =
-      (for {
-        current   <- ref.get
-        _         <- ZIO.sleep(current.token.expiresInOfPercent(refreshAtExpirationPercent))
-        refreshed <- requestToken.retry(refreshRetrySchedule)
-        _         <- ref.update(_ => refreshed)
-      } yield ()).repeat[Any, Long](Schedule.forever)
-
-    for {
-      token <- requestToken
-      ref   <- zio.Ref.make(token)
-      _     <- refreshTokenJob(ref).forkScoped
-    } yield new TokenProvider[T] {
-      override def token: UIO[TokenReceipt[T]] = ref.get
-    }
+    autoRefreshTokenProvider(requestToken, refreshRetrySchedule, refreshAtExpirationPercent)
   }
 
   def defaultAccessTokenProvider(
@@ -147,6 +194,14 @@ object TokenProvider {
             )
           )
         )
+      case _: ImpersonatedServiceAccount =>
+        ZIO.fail(
+          TokenProviderException.CredentialsFailure(
+            CredentialsException.InvalidCredentialsFile(
+              s"Getting ID token by impersonated service account credentials is not supported."
+            )
+          )
+        )
     }
 
   def accessTokenProvider(
@@ -179,6 +234,37 @@ object TokenProvider {
             )
           )
         )
+      case impersonated: ImpersonatedServiceAccount =>
+        for {
+          sourceProvider <- accessTokenProvider(
+                              impersonated.sourceCredentials,
+                              backend,
+                              refreshRetrySchedule,
+                              refreshAtExpirationPercent,
+                            )
+          provider <- autoRefreshTokenProvider(
+                        requestToken = for {
+                          sourceReceipt <- sourceProvider.token
+                          _             <- ZIO.log("Requesting new impersonated access token...")
+                          token         <- backend
+                                     .send(
+                                       generateAccessTokenReq(
+                                         impersonated.serviceAccountImpersonationUrl,
+                                         sourceReceipt.token.token,
+                                         impersonated.scopes,
+                                         impersonated.delegates,
+                                       )
+                                     )
+                                     .mapError(e => TokenProviderException.Unexpected(e))
+                                     .flatMap(responseToToken)
+                          now <- Clock.instant
+                          _   <-
+                            ZIO.log(s"Retrieved new impersonated token with expiry in ${token.expiresIn.getSeconds()}s")
+                        } yield TokenReceipt(token, now),
+                        refreshRetrySchedule = refreshRetrySchedule,
+                        refreshAtExpirationPercent = refreshAtExpirationPercent,
+                      )
+        } yield provider
     }
 
   def noTokenProvider: TokenProvider[Token] = new TokenProvider[Token] {

--- a/zio-gcp-auth/shared/src/test/resources/impersonated_service_account.json
+++ b/zio-gcp-auth/shared/src/test/resources/impersonated_service_account.json
@@ -1,0 +1,13 @@
+{
+    "delegates": [],
+    "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/example@example-project.iam.gserviceaccount.com:generateAccessToken",
+    "source_credentials": {
+        "account": "",
+        "client_id": "123.apps.googleusercontent.com",
+        "client_secret": "secret",
+        "refresh_token": "refresh_token",
+        "type": "authorized_user",
+        "universe_domain": "googleapis.com"
+    },
+    "type": "impersonated_service_account"
+}

--- a/zio-gcp-auth/shared/src/test/scala/anymindgroup/gcp/auth/CredentialsSpec.scala
+++ b/zio-gcp-auth/shared/src/test/scala/anymindgroup/gcp/auth/CredentialsSpec.scala
@@ -70,6 +70,27 @@ object CredentialsSpec extends ZIOSpecDefault {
              })
       } yield assertCompletes
     }.provideLayer(defaultTestLayer),
+    test("read impersonated service account credentials from file") {
+      val impersonatedCredsPath =
+        Path.of(resourcesDir.toString(), "impersonated_service_account.json").toAbsolutePath()
+
+      for {
+        _     <- TestSystem.putEnv("GOOGLE_APPLICATION_CREDENTIALS", impersonatedCredsPath.toString())
+        creds <- ZIO.serviceWithZIO[Backend[Task]](Credentials.auto(_))
+        _     <- assertTrue(creds match {
+               case Some(
+                     Credentials.ImpersonatedServiceAccount(
+                       "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/example@example-project.iam.gserviceaccount.com:generateAccessToken",
+                       Credentials.UserAccount("refresh_token", "123.apps.googleusercontent.com", _),
+                       Nil,
+                       _,
+                     )
+                   ) =>
+                 true
+               case _ => false
+             })
+      } yield assertCompletes
+    }.provideLayer(defaultTestLayer),
   )
 
   val resourcesDir: Path = Path.of("zio-gcp-auth", "shared", "src", "test", "resources").toAbsolutePath()

--- a/zio-gcp-auth/shared/src/test/scala/anymindgroup/gcp/auth/CredentialsSpec.scala
+++ b/zio-gcp-auth/shared/src/test/scala/anymindgroup/gcp/auth/CredentialsSpec.scala
@@ -89,6 +89,11 @@ object CredentialsSpec extends ZIOSpecDefault {
                  true
                case _ => false
              })
+        _ <- assertTrue(
+               creds.get
+                 .asInstanceOf[Credentials.ImpersonatedServiceAccount]
+                 .serviceAccountEmail == "example@example-project.iam.gserviceaccount.com"
+             )
       } yield assertCompletes
     }.provideLayer(defaultTestLayer),
   )

--- a/zio-gcp-auth/shared/src/test/scala/anymindgroup/gcp/auth/TokenProviderSpec.scala
+++ b/zio-gcp-auth/shared/src/test/scala/anymindgroup/gcp/auth/TokenProviderSpec.scala
@@ -19,6 +19,13 @@ object TokenProviderSpec extends ZIOSpecDefault {
   val failUserAccount: Credentials.UserAccount = Credentials.UserAccount("token", "fail_user", Config.Secret("123"))
   val testIdToken                              =
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE1MTYyMzkxMjJ9.-fM8Z-u88K5GGomqJxRCilYkjXZusY_Py6kdyzh1EAg"
+  val impersonationUrl: String =
+    "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/example@example-project.iam.gserviceaccount.com:generateAccessToken"
+  val impersonatedCreds: Credentials.ImpersonatedServiceAccount =
+    Credentials.ImpersonatedServiceAccount(
+      serviceAccountImpersonationUrl = impersonationUrl,
+      sourceCredentials = okUserAccount,
+    )
 
   override def spec: Spec[TestEnvironment & Scope, Any] = suite("TokenProviderSpec")(
     test("no token provider") {
@@ -56,6 +63,14 @@ object TokenProviderSpec extends ZIOSpecDefault {
              )
       } yield assertCompletes
     }.provideSome[Scope](googleStubBackendLayer()),
+    test("fail on getting id token for impersonated service account as it's not supported (yet)") {
+      for {
+        backend <- ZIO.service[Backend[Task]]
+        _       <- assertZIO(TokenProvider.idTokenProvider("", impersonatedCreds, backend).exit)(
+               failsWithA[TokenProviderException.CredentialsFailure]
+             )
+      } yield assertCompletes
+    }.provideSome[Scope](googleStubBackendLayer()),
     test("request access token from compute metadata server") {
       for {
         backend <- ZIO.service[Backend[Task]]
@@ -73,6 +88,25 @@ object TokenProviderSpec extends ZIOSpecDefault {
         _       <- assertTrue(token.token.token == testIdToken)
       } yield assertCompletes).provideSome[Scope](googleStubBackendLayer(audience))
     },
+    test("request access token using impersonated service account credentials") {
+      for {
+        backend <- ZIO.service[Backend[Task]]
+        tp      <- TokenProvider.accessTokenProvider(impersonatedCreds, backend)
+        token   <- tp.token
+        _       <- assertTrue(token.token.token == "impersonated")
+      } yield assertCompletes
+    }.provideSome[Scope](googleStubBackendLayer()),
+    test("request access token using impersonated service account with delegates") {
+      val credsWithDelegates = impersonatedCreds.copy(
+        delegates = List("delegate@example-project.iam.gserviceaccount.com")
+      )
+      for {
+        backend <- ZIO.service[Backend[Task]]
+        tp      <- TokenProvider.accessTokenProvider(credsWithDelegates, backend)
+        token   <- tp.token
+        _       <- assertTrue(token.token.token == "impersonated")
+      } yield assertCompletes
+    }.provideSome[Scope](googleStubBackendLayer()),
     test("token is refreshed automatically at given expiry stage") {
       checkN(10)(Gen.double(0.1, 0.9)) { expiryPercent =>
         for {
@@ -144,6 +178,18 @@ object TokenProviderSpec extends ZIOSpecDefault {
       }
       .thenRespondAdjust(
         s"""{"access_token":"user","expires_in":$tokenExpirySeconds,"token_type":"Bearer"}"""
+      )
+      .whenRequestMatches { r =>
+        r.method == Method.POST && r.uri.toString() == impersonationUrl && (r.body match {
+          case StringBody(s, _, _) =>
+            s.contains("scope") && r.headers.exists(h =>
+              h.name.equalsIgnoreCase("Authorization") && h.value.startsWith("Bearer ")
+            )
+          case _ => false
+        })
+      }
+      .thenRespondAdjust(
+        s"""{"accessToken":"impersonated","expireTime":"2999-01-01T00:00:00Z"}"""
       )
       .whenRequestMatches { r =>
         r.uri.toString() == "https://oauth2.googleapis.com/token" && (r.body match {


### PR DESCRIPTION
## Summary

- Adds `Credentials.ImpersonatedServiceAccount` type with `serviceAccountImpersonationUrl`, `sourceCredentials`, `delegates`, and `scopes` fields
- Extends `ApplicationCredentials` JSON decoder to parse `impersonated_service_account` credential files (including recursive `source_credentials` decoding via `allowRecursiveTypes`)
- Changes `Credentials.applicationCredentials` return type from `Option[CredentialsKey]` to `Option[Credentials]` to accommodate the new type
- Adds `generateAccessTokenReq` helper in `TokenProvider` that POSTs to the impersonation URL with a source bearer token, parsing the `{"accessToken": "...", "expireTime": "..."}` response
- Refactors `autoRefreshTokenProviderByRequest` to extract a reusable `autoRefreshTokenProvider` — used by the new impersonated token flow which chains source token refresh with impersonation URL calls

## Test plan

- [x] `CredentialsSpec`: reads `impersonated_service_account.json` resource, verifies correct `ImpersonatedServiceAccount` is parsed with nested `UserAccount` source credentials
- [x] `TokenProviderSpec`: requests access token via impersonated credentials (with and without delegates), verifies id-token path returns unsupported error
- [x] JVM and Native targets compile cleanly

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)