### PR TITLE
Add Gemini function calling support

### DIFF
--- a/docs/aiplatform/index.md
+++ b/docs/aiplatform/index.md
@@ -2,32 +2,36 @@
 
 Client for [Google Cloud Vertex AI API](https://cloud.google.com/vertex-ai/docs/reference/rest).
 
+The `zio-gcp-aiplatform` module provides an `ExpressModelClient` convenience layer built on top of the generated API client, with integrated support for [ZIO Schema](https://zio.dev/zio-schema/). You can define case classes with `derives Schema` to use as structured response schemas (enforcing JSON output shape) or as function parameter/return types in function calling — schemas are automatically converted to Vertex AI's `GoogleCloudAiplatformV1Schema` format.
+
 ## Getting Started
 
 To get started with sbt, add the dependency to your project in `build.sbt`
 ```scala
 libraryDependencies ++= Seq(
   "com.anymindgroup" %% "zio-gcp-auth" % "@VERSION@",
-  "com.anymindgroup" %% "zio-gcp-aiplatform-v1" % "@VERSION@",
+  "com.anymindgroup" %% "zio-gcp-aiplatform" % "@VERSION@",
 )
 ```
 
-The module provides an `ExpressModelClient` convenience layer built on top of the generated API client, with integrated support for [ZIO Schema](https://zio.dev/zio-schema/). You can define case classes with `derives Schema` to use as structured response schemas (enforcing JSON output shape) or as function parameter/return types in function calling — schemas are automatically converted to Vertex AI's `GoogleCloudAiplatformV1Schema` format.
+## Express client usage examples
 
-## Usage examples
+#### Simple text generation:
 
-#### Generate text via the Express client (text-only input):
+<<< @/../examples/shared/src/main/scala/express_vertex_ai_text.scala{scala}
 
-<<< @/../examples/shared/src/main/scala/express_vertex_ai_from_text.scala{scala}
+#### Generate structured output from text:
 
-#### Generate structured output via the Express client (request construction):
+<<< @/../examples/shared/src/main/scala/express_vertex_ai_schema.scala{scala}
 
-<<< @/../examples/shared/src/main/scala/express_vertex_ai_request.scala{scala}
+#### Generate structured output with a custom request:
+
+<<< @/../examples/shared/src/main/scala/express_vertex_ai_custom_req.scala{scala}
+
+####  Generate structured output with a custom request and functions:
+
+<<< @/../examples/shared/src/main/scala/express_vertex_ai_function_calling.scala{scala}
 
 #### Generate content via the raw API client:
 
 <<< @/../examples/shared/src/main/scala/vertex_ai_generate_content.scala{scala}
-
-#### Function calling via the Express client:
-
-<<< @/../examples/shared/src/main/scala/express_vertex_ai_function_calling.scala{scala}

--- a/docs/aiplatform/index.md
+++ b/docs/aiplatform/index.md
@@ -28,7 +28,7 @@ libraryDependencies ++= Seq(
 
 <<< @/../examples/shared/src/main/scala/express_vertex_ai_custom_req.scala{scala}
 
-####  Generate structured output with a custom request and functions:
+#### Generate structured output with a custom request and functions:
 
 <<< @/../examples/shared/src/main/scala/express_vertex_ai_function_calling.scala{scala}
 

--- a/docs/aiplatform/index.md
+++ b/docs/aiplatform/index.md
@@ -2,7 +2,7 @@
 
 Client for [Google Cloud Vertex AI API](https://cloud.google.com/vertex-ai/docs/reference/rest).
 
-The `zio-gcp-aiplatform` module provides an `ExpressModelClient` convenience layer built on top of the generated API client, with integrated support for [ZIO Schema](https://zio.dev/zio-schema/). You can define case classes with `derives Schema` to use as structured response schemas (enforcing JSON output shape) or as function parameter/return types in function calling — schemas are automatically converted to Vertex AI's `GoogleCloudAiplatformV1Schema` format.
+The `zio-gcp-aiplatform` module provides an `ExpressModelClient` convenience layer built on top of the generated API client, with integrated support for [ZIO Schema](https://zio.dev/zio-schema/) and [function-calling](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/tools/function-calling) tools. You can define case classes with `derives Schema` to use as structured response schemas (enforcing JSON output shape) or as function parameter/return types in function calling — schemas are automatically converted to [OpenAPI schema](https://spec.openapis.org/oas/v3.0.3#schema) format for the Vertex AI API.
 
 ## Getting Started
 

--- a/docs/aiplatform/index.md
+++ b/docs/aiplatform/index.md
@@ -12,6 +12,8 @@ libraryDependencies ++= Seq(
 )
 ```
 
+The module provides an `ExpressModelClient` convenience layer built on top of the generated API client, with integrated support for [ZIO Schema](https://zio.dev/zio-schema/). You can define case classes with `derives Schema` to use as structured response schemas (enforcing JSON output shape) or as function parameter/return types in function calling — schemas are automatically converted to Vertex AI's `GoogleCloudAiplatformV1Schema` format.
+
 ## Usage examples
 
 #### Generate text via the Express client (text-only input):
@@ -25,3 +27,7 @@ libraryDependencies ++= Seq(
 #### Generate content via the raw API client:
 
 <<< @/../examples/shared/src/main/scala/vertex_ai_generate_content.scala{scala}
+
+#### Function calling via the Express client:
+
+<<< @/../examples/shared/src/main/scala/express_vertex_ai_function_calling.scala{scala}

--- a/examples/shared/src/main/scala/express_vertex_ai_custom_req.scala
+++ b/examples/shared/src/main/scala/express_vertex_ai_custom_req.scala
@@ -1,0 +1,42 @@
+import zio.*, zio.schema.*, com.anymindgroup.gcp.auth.defaultAccessTokenBackend
+import com.anymindgroup.gcp.aiplatform.v1.schemas.*
+import com.anymindgroup.gcp.aiplatform.*
+import com.github.plokhotnyuk.jsoniter_scala as json
+
+object express_vertex_ai_custom_req extends ZIOAppDefault:
+  def run = for
+    authedBackend <- defaultAccessTokenBackend()
+    express        = ExpressModelClient(
+                backend = authedBackend,
+                projectsId = "my-gcp-project",
+                locationsId = "global",
+                publishersId = "google",
+                modelsId = "gemini-3.5-flash",
+              )
+
+    msg = GenerateContentRequest(
+            contents = Chunk(
+              GoogleCloudAiplatformV1Content(
+                parts = Chunk(GoogleCloudAiplatformV1Part(text = Some("hello, my name is John"))),
+                role = Some("user"),
+              ),
+              GoogleCloudAiplatformV1Content(
+                parts = Chunk(GoogleCloudAiplatformV1Part(text = Some("I'm 24 years old"))),
+                role = Some("user"),
+              ),
+              GoogleCloudAiplatformV1Content(
+                parts = Chunk(GoogleCloudAiplatformV1Part(text = Some("I am from the US"))),
+                role = Some("user"),
+              ),
+            ),
+            responseSchema = Schema[Person],
+          ).withSystemInstructions("extract person's information from the conversation")
+
+    person <- express.generate[Person](msg)
+    _       = println("Name: " + person.name)
+    _       = println("Age: " + person.age)
+    _       = println("Country: " + person.country)
+  yield ()
+
+  case class Person(name: Option[String], age: Option[Int], country: Option[String]) derives Schema
+  given json.core.JsonValueCodec[Person] = json.macros.JsonCodecMaker.make

--- a/examples/shared/src/main/scala/express_vertex_ai_function_calling.scala
+++ b/examples/shared/src/main/scala/express_vertex_ai_function_calling.scala
@@ -1,0 +1,43 @@
+import zio.*, zio.schema.*, com.anymindgroup.gcp.auth.defaultAccessTokenBackend
+import com.anymindgroup.gcp.aiplatform.v1.schemas.*
+import com.anymindgroup.gcp.aiplatform.*
+import com.github.plokhotnyuk.jsoniter_scala as json
+
+object express_vertex_ai_function_calling extends ZIOAppDefault:
+  def run = for
+    authedBackend <- defaultAccessTokenBackend()
+    express        = ExpressModelClient(
+                backend = authedBackend,
+                projectsId = "anychat-staging",
+                locationsId = "global",
+                publishersId = "google",
+                modelsId = "gemini-3.5-flash",
+              )
+
+    msg = GenerateContentRequest(
+            contents = Chunk(
+              GoogleCloudAiplatformV1Content(
+                parts = Chunk(GoogleCloudAiplatformV1Part(text = Some("What is the weather like in Tokyo?"))),
+                role = Some("user"),
+              )
+            ),
+            responseSchema = Schema[WeatherResult],
+          )
+
+    res <- express.send(
+             baseRequest = msg,
+             functions = Map(
+                "get_weather" -> FunctionDeclaration(
+                  function =
+                    (city: City) => ZIO.succeed(WeatherResult(temperature = 22, unit = "celsius", conditions = "Sunny")),
+                  description = Some("Get the current weather for a given city"),
+                )
+             ),
+           )
+    _ = println(s"Result: $res")
+  yield ()
+
+  case class City(name: String) derives Schema
+  given json.core.JsonValueCodec[City] = json.macros.JsonCodecMaker.make
+  case class WeatherResult(temperature: Int, unit: String, conditions: String) derives Schema
+  given json.core.JsonValueCodec[WeatherResult] = json.macros.JsonCodecMaker.make

--- a/examples/shared/src/main/scala/express_vertex_ai_function_calling.scala
+++ b/examples/shared/src/main/scala/express_vertex_ai_function_calling.scala
@@ -8,7 +8,7 @@ object express_vertex_ai_function_calling extends ZIOAppDefault:
     authedBackend <- defaultAccessTokenBackend()
     express        = ExpressModelClient(
                 backend = authedBackend,
-                projectsId = "anychat-staging",
+                projectsId = "my-gcp-project",
                 locationsId = "global",
                 publishersId = "google",
                 modelsId = "gemini-3.5-flash",

--- a/examples/shared/src/main/scala/express_vertex_ai_schema.scala
+++ b/examples/shared/src/main/scala/express_vertex_ai_schema.scala
@@ -1,9 +1,8 @@
 import zio.*, zio.schema.*, com.anymindgroup.gcp.auth.defaultAccessTokenBackend
-import com.anymindgroup.gcp.aiplatform.v1.schemas.*
-import com.anymindgroup.gcp.aiplatform.*
+import com.anymindgroup.gcp.aiplatform.ExpressModelClient
 import com.github.plokhotnyuk.jsoniter_scala as json
 
-object express_vertex_ai_request extends ZIOAppDefault:
+object express_vertex_ai_schema extends ZIOAppDefault:
   def run = for
     authedBackend <- defaultAccessTokenBackend()
     express        = ExpressModelClient(
@@ -13,18 +12,7 @@ object express_vertex_ai_request extends ZIOAppDefault:
                 publishersId = "google",
                 modelsId = "gemini-3.5-flash",
               )
-
-    msg = GenerateContentRequest(
-            contents = Chunk(
-              GoogleCloudAiplatformV1Content(
-                parts = Chunk(GoogleCloudAiplatformV1Part(text = Some("hello how are you doing?"))),
-                role = Some("user"),
-              )
-            ),
-            responseSchema = Schema[Joke],
-          ).withSystemInstructions("just reply to the question")
-
-    joke <- express.generate[Joke](msg)
+    joke <- express.generate[Joke]("Tell me a joke")
     _     = println("Joke: " + joke.setup + " \u2014 " + joke.punchline)
   yield ()
 

--- a/examples/shared/src/main/scala/express_vertex_ai_text.scala
+++ b/examples/shared/src/main/scala/express_vertex_ai_text.scala
@@ -1,8 +1,7 @@
-import zio.*, zio.schema.*, com.anymindgroup.gcp.auth.defaultAccessTokenBackend
+import zio.*, com.anymindgroup.gcp.auth.defaultAccessTokenBackend
 import com.anymindgroup.gcp.aiplatform.ExpressModelClient
-import com.github.plokhotnyuk.jsoniter_scala as json
 
-object express_vertex_ai_from_text extends ZIOAppDefault:
+object express_vertex_ai_text extends ZIOAppDefault:
   def run = for
     authedBackend <- defaultAccessTokenBackend()
     express        = ExpressModelClient(
@@ -12,13 +11,6 @@ object express_vertex_ai_from_text extends ZIOAppDefault:
                 publishersId = "google",
                 modelsId = "gemini-3.5-flash",
               )
-
     txt <- express.generateText("hello how are you doing?")
     _    = println("Text response: " + txt)
-
-    joke <- express.generate[Joke]("Tell me a joke")
-    _     = println("Joke: " + joke.setup + " \u2014 " + joke.punchline)
   yield ()
-
-  case class Joke(setup: String, punchline: String) derives Schema
-  given json.core.JsonValueCodec[Joke] = json.macros.JsonCodecMaker.make

--- a/zio-gcp-aiplatform/shared/src/main/scala/com/anymindgroup/gcp/aiplatform/ExpressModelClient.scala
+++ b/zio-gcp-aiplatform/shared/src/main/scala/com/anymindgroup/gcp/aiplatform/ExpressModelClient.scala
@@ -2,14 +2,19 @@ package com.anymindgroup.gcp.aiplatform
 
 import com.anymindgroup.gcp.aiplatform.v1.resources.projects.locations.publishers
 import com.anymindgroup.gcp.aiplatform.v1.schemas.{
+  GoogleCloudAiplatformV1Content,
+  GoogleCloudAiplatformV1FunctionCall,
+  GoogleCloudAiplatformV1FunctionResponse,
   GoogleCloudAiplatformV1GenerateContentRequest,
   GoogleCloudAiplatformV1GenerateContentResponse,
+  GoogleCloudAiplatformV1Part,
 }
+import com.anymindgroup.jsoniter.Json
 import com.github.plokhotnyuk.jsoniter_scala.core.*
 import sttp.client4.Backend
 
 import zio.schema.Schema
-import zio.{Task, ZIO}
+import zio.{Chunk, Task, ZIO}
 
 // express client with fixed location and model for generating content
 class ExpressModelClient(
@@ -34,6 +39,81 @@ class ExpressModelClient(
       )
       .flatMap(res => ZIO.fromEither(res.body))
 
+  def send(
+    baseRequest: GoogleCloudAiplatformV1GenerateContentRequest,
+    functions: Map[String, FunctionDeclaration[?, ?]],
+  ): Task[GoogleCloudAiplatformV1GenerateContentResponse] = ZIO.suspendSucceed {
+    val baseReqWithFunctions = baseRequest.withFunctions(functions)
+
+    def processFnCall(
+      fnName: String,
+      fnCall: GoogleCloudAiplatformV1FunctionCall,
+    ): Task[GoogleCloudAiplatformV1Content] =
+      for
+        fn     <- ZIO.fromEither(functions.get(fnName).toRight(Throwable(s"Unknown function: $fnName")))
+        input   = fnCall.args.getOrElse(Json.codec.nullValue)
+        output <- fn(input)
+      yield GoogleCloudAiplatformV1Content(
+        parts = Chunk(
+          GoogleCloudAiplatformV1Part(
+            functionResponse = Some(
+              GoogleCloudAiplatformV1FunctionResponse(
+                name = fnName,
+                response = fn.encodeOutput(output),
+              )
+            )
+          )
+        ),
+        role = Some("user"),
+      )
+
+    def loop(contents: Chunk[GoogleCloudAiplatformV1Content]): Task[GoogleCloudAiplatformV1GenerateContentResponse] =
+      val req = baseReqWithFunctions.copy(contents = contents)
+      send(req).flatMap { resp =>
+        val fnCalls = resp.candidates
+          .to(Chunk)
+          .flatMap(_.flatMap(_.content.to(Chunk)))
+          .flatMap: content =>
+            content.parts.collect:
+              case GoogleCloudAiplatformV1Part(
+                    _,
+                    _,
+                    _,
+                    Some(fn @ GoogleCloudAiplatformV1FunctionCall(_, Some(name), _, _)),
+                    _,
+                    _,
+                    _,
+                    _,
+                    _,
+                    Some(thoughtSignature),
+                    _,
+                  ) =>
+                (thoughtSignature, name, fn)
+
+        if fnCalls.isEmpty then ZIO.succeed(resp)
+        else
+          ZIO
+            .foreachPar(fnCalls) { (thoughtSignature, name, fn) =>
+              processFnCall(name, fn).map { fnRespContent =>
+                // echo back the function call with its thoughtSignature
+                val modelFnContent = GoogleCloudAiplatformV1Content(
+                  parts = Chunk(
+                    GoogleCloudAiplatformV1Part(
+                      functionCall = Some(fn),
+                      thoughtSignature = Some(thoughtSignature),
+                    )
+                  ),
+                  role = Some("model"),
+                )
+                Chunk(modelFnContent, fnRespContent)
+              }
+            }
+            .flatMap(results => loop(contents ++ results.flatten))
+      }
+
+    loop(baseRequest.contents)
+  }
+
   def generateText(req: GoogleCloudAiplatformV1GenerateContentRequest): Task[String] =
     send(req).map(_.text)
 
@@ -48,8 +128,21 @@ class ExpressModelClient(
     generate(req = req, decodeResponse = _.decodeText[R])
 
   def generate[R](
+    baseRequest: GoogleCloudAiplatformV1GenerateContentRequest,
+    functions: Map[String, FunctionDeclaration[?, ?]],
+  )(using c: JsonValueCodec[R]): Task[R] =
+    generate(baseRequest = baseRequest, functions = functions, decodeResponse = _.decodeText[R])
+
+  def generate[R](
     req: GoogleCloudAiplatformV1GenerateContentRequest,
     decodeResponse: GoogleCloudAiplatformV1GenerateContentResponse => Either[Throwable, R],
   ): Task[R] =
     send(req).flatMap(res => ZIO.fromEither(decodeResponse(res)))
+
+  def generate[R](
+    baseRequest: GoogleCloudAiplatformV1GenerateContentRequest,
+    functions: Map[String, FunctionDeclaration[?, ?]],
+    decodeResponse: GoogleCloudAiplatformV1GenerateContentResponse => Either[Throwable, R],
+  ): Task[R] =
+    send(baseRequest, functions).flatMap(res => ZIO.fromEither(decodeResponse(res)))
 }

--- a/zio-gcp-aiplatform/shared/src/main/scala/com/anymindgroup/gcp/aiplatform/ExpressModelClient.scala
+++ b/zio-gcp-aiplatform/shared/src/main/scala/com/anymindgroup/gcp/aiplatform/ExpressModelClient.scala
@@ -9,12 +9,19 @@ import com.anymindgroup.gcp.aiplatform.v1.schemas.{
   GoogleCloudAiplatformV1GenerateContentResponse,
   GoogleCloudAiplatformV1Part,
 }
-import com.anymindgroup.jsoniter.Json
 import com.github.plokhotnyuk.jsoniter_scala.core.*
 import sttp.client4.Backend
 
 import zio.schema.Schema
 import zio.{Chunk, Task, ZIO}
+
+sealed abstract class FunctionCallException(message: String) extends Throwable(message)
+object FunctionCallException {
+  final case class UnknownFunction(name: String) extends FunctionCallException(s"Unknown function: $name")
+  final case class MissingArguments(name: String)
+      extends FunctionCallException(s"Missing arguments for function call: $name")
+  case object MissingFunctionName extends FunctionCallException("Received a function call without a name")
+}
 
 // express client with fixed location and model for generating content
 class ExpressModelClient(
@@ -50,8 +57,8 @@ class ExpressModelClient(
       fnCall: GoogleCloudAiplatformV1FunctionCall,
     ): Task[GoogleCloudAiplatformV1Content] =
       for
-        fn     <- ZIO.fromEither(functions.get(fnName).toRight(Throwable(s"Unknown function: $fnName")))
-        input   = fnCall.args.getOrElse(Json.codec.nullValue)
+        fn     <- ZIO.fromEither(functions.get(fnName).toRight(FunctionCallException.UnknownFunction(fnName)))
+        input  <- ZIO.fromOption(fnCall.args).orElseFail(FunctionCallException.MissingArguments(fnName))
         output <- fn(input)
       yield GoogleCloudAiplatformV1Content(
         parts = Chunk(
@@ -71,36 +78,25 @@ class ExpressModelClient(
       val req = baseReqWithFunctions.copy(contents = contents)
       send(req).flatMap { resp =>
         val fnCalls = resp.candidates
-          .to(Chunk)
-          .flatMap(_.flatMap(_.content.to(Chunk)))
-          .flatMap: content =>
-            content.parts.collect:
-              case GoogleCloudAiplatformV1Part(
-                    _,
-                    _,
-                    _,
-                    Some(fn @ GoogleCloudAiplatformV1FunctionCall(_, Some(name), _, _)),
-                    _,
-                    _,
-                    _,
-                    _,
-                    _,
-                    Some(thoughtSignature),
-                    _,
-                  ) =>
-                (thoughtSignature, name, fn)
+          .getOrElse(Chunk.empty)
+          .flatMap(_.content.to(Chunk))
+          .flatMap(_.parts)
+          .flatMap(part => part.functionCall.map((part, _)))
 
         if fnCalls.isEmpty then ZIO.succeed(resp)
         else
           ZIO
-            .foreachPar(fnCalls) { (thoughtSignature, name, fn) =>
-              processFnCall(name, fn).map { fnRespContent =>
-                // echo back the function call with its thoughtSignature
+            .foreachPar(fnCalls) { (part, fnCall) =>
+              for
+                name          <- ZIO.fromOption(fnCall.name).orElseFail(FunctionCallException.MissingFunctionName)
+                fnRespContent <- processFnCall(name, fnCall)
+              yield {
+                // echo back the function call with its thought signature (if present)
                 val modelFnContent = GoogleCloudAiplatformV1Content(
                   parts = Chunk(
                     GoogleCloudAiplatformV1Part(
-                      functionCall = Some(fn),
-                      thoughtSignature = Some(thoughtSignature),
+                      functionCall = Some(fnCall),
+                      thoughtSignature = part.thoughtSignature,
                     )
                   ),
                   role = Some("model"),

--- a/zio-gcp-aiplatform/shared/src/main/scala/com/anymindgroup/gcp/aiplatform/FunctionDeclaration.scala
+++ b/zio-gcp-aiplatform/shared/src/main/scala/com/anymindgroup/gcp/aiplatform/FunctionDeclaration.scala
@@ -1,0 +1,40 @@
+package com.anymindgroup.gcp.aiplatform
+
+import com.anymindgroup.gcp.aiplatform.v1.schemas.GoogleCloudAiplatformV1Schema
+import com.anymindgroup.jsoniter.Json
+import com.github.plokhotnyuk.jsoniter_scala.core.*
+
+import zio.schema.Schema
+import zio.{Task, ZIO}
+
+// functionDeclaration parameters schema should be of type OBJECT.
+// Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/function-calling
+case class FunctionDeclaration[A <: Product, B <: Product](
+  function: A => Task[B],
+  description: Option[String],
+  decodeInput: Json => Either[Throwable, A],
+  encodeOutput: B => com.anymindgroup.jsoniter.Json,
+)(using inSchema: Schema[A], outSchema: Schema[B]) {
+  val inputSchema: GoogleCloudAiplatformV1Schema = AiPlatformSchema.toGoogleCloudAiplatformV1Schema(inSchema)
+
+  val outputSchema: GoogleCloudAiplatformV1Schema = AiPlatformSchema.toGoogleCloudAiplatformV1Schema(outSchema)
+
+  def apply(input: Json): Task[B] = ZIO.fromEither(decodeInput(input)).flatMap(function(_))
+}
+
+object FunctionDeclaration {
+  def apply[A <: Product, B <: Product](
+    function: A => Task[B],
+    description: Option[String],
+  )(using
+    inSchema: Schema[A],
+    outSchema: Schema[B],
+    inputCodec: JsonValueCodec[A],
+    outputCodec: JsonValueCodec[B],
+  ): FunctionDeclaration[A, B] = FunctionDeclaration(
+    function = function,
+    description = description,
+    decodeInput = _.readAs[A],
+    encodeOutput = (out: B) => Json.writeToJson(out),
+  )
+}

--- a/zio-gcp-aiplatform/shared/src/main/scala/com/anymindgroup/gcp/aiplatform/GenerateContentRequest.scala
+++ b/zio-gcp-aiplatform/shared/src/main/scala/com/anymindgroup/gcp/aiplatform/GenerateContentRequest.scala
@@ -2,10 +2,12 @@ package com.anymindgroup.gcp.aiplatform
 
 import com.anymindgroup.gcp.aiplatform.v1.schemas.{
   GoogleCloudAiplatformV1Content,
+  GoogleCloudAiplatformV1FunctionDeclaration,
   GoogleCloudAiplatformV1GenerateContentRequest,
   GoogleCloudAiplatformV1GenerationConfig,
   GoogleCloudAiplatformV1Part,
   GoogleCloudAiplatformV1Schema,
+  GoogleCloudAiplatformV1Tool,
 }
 
 import zio.Chunk
@@ -68,3 +70,32 @@ extension (r: GoogleCloudAiplatformV1GenerateContentRequest)
       )
     )
   )
+
+  def withFunctions(
+    functions: Map[String, FunctionDeclaration[?, ?]]
+  ): GoogleCloudAiplatformV1GenerateContentRequest =
+    val funcTools = GoogleCloudAiplatformV1Tool(
+      functionDeclarations = Some(Chunk.fromIterable(functions.map { case (name, fn) =>
+        GoogleCloudAiplatformV1FunctionDeclaration(
+          name = name,
+          description = fn.description,
+          parameters = Some(fn.inputSchema),
+          response = Some(fn.outputSchema),
+        )
+      }))
+    )
+
+    r.copy(tools =
+      Some(
+        r.tools match
+          case None        => Chunk(funcTools)
+          case Some(tools) =>
+            tools.map(tool =>
+              tool.copy(
+                functionDeclarations =
+                  // ensure functions with the same name are filtered out to to prevent from conflicts
+                  tool.functionDeclarations.map(_.filterNot(f => functions.keySet.contains(f.name)))
+              )
+            ) :+ funcTools
+      )
+    )

--- a/zio-gcp-aiplatform/shared/src/main/scala/com/anymindgroup/gcp/aiplatform/GenerateContentRequest.scala
+++ b/zio-gcp-aiplatform/shared/src/main/scala/com/anymindgroup/gcp/aiplatform/GenerateContentRequest.scala
@@ -75,7 +75,8 @@ extension (r: GoogleCloudAiplatformV1GenerateContentRequest)
     functions: Map[String, FunctionDeclaration[?, ?]]
   ): GoogleCloudAiplatformV1GenerateContentRequest =
     val funcTools = GoogleCloudAiplatformV1Tool(
-      functionDeclarations = Some(Chunk.fromIterable(functions.map { case (name, fn) =>
+      // sort by function name to keep the emitted declarations deterministic across runs
+      functionDeclarations = Some(Chunk.fromIterable(functions.toSeq.sortBy(_._1).map { case (name, fn) =>
         GoogleCloudAiplatformV1FunctionDeclaration(
           name = name,
           description = fn.description,
@@ -93,7 +94,7 @@ extension (r: GoogleCloudAiplatformV1GenerateContentRequest)
             tools.map(tool =>
               tool.copy(
                 functionDeclarations =
-                  // ensure functions with the same name are filtered out to to prevent from conflicts
+                  // ensure functions with the same name are filtered out to prevent conflicts
                   tool.functionDeclarations.map(_.filterNot(f => functions.keySet.contains(f.name)))
               )
             ) :+ funcTools

--- a/zio-gcp-aiplatform/shared/src/test/scala/com/anymindgroup/gcp/aiplatform/ExpressModelClientSpec.scala
+++ b/zio-gcp-aiplatform/shared/src/test/scala/com/anymindgroup/gcp/aiplatform/ExpressModelClientSpec.scala
@@ -42,8 +42,8 @@ object ExpressModelClientSpec extends ZIOSpecDefault {
       )
     ).toJsonString
 
-  // builds a response with one candidate holding one function call part per provided call.
-  // a thoughtSignature must be present for the client to pick up the function call.
+  // builds a response with one candidate holding one function call part per provided call,
+  // each carrying a thought signature that the client echoes back to the model.
   private def functionCallResponse(calls: (String, Json, String)*): String =
     GoogleCloudAiplatformV1GenerateContentResponse(
       candidates = Some(
@@ -57,6 +57,27 @@ object ExpressModelClientSpec extends ZIOSpecDefault {
                     thoughtSignature = Some(signature),
                   )
                 }),
+                role = Some("model"),
+              )
+            )
+          )
+        )
+      )
+    ).toJsonString
+
+  // builds a response with a single function call part that carries no thought signature
+  private def functionCallResponseWithoutSignature(name: String, args: Json): String =
+    GoogleCloudAiplatformV1GenerateContentResponse(
+      candidates = Some(
+        Chunk(
+          GoogleCloudAiplatformV1Candidate(
+            content = Some(
+              GoogleCloudAiplatformV1Content(
+                parts = Chunk(
+                  GoogleCloudAiplatformV1Part(
+                    functionCall = Some(GoogleCloudAiplatformV1FunctionCall(name = Some(name), args = Some(args)))
+                  )
+                ),
                 role = Some("model"),
               )
             )
@@ -196,7 +217,33 @@ object ExpressModelClientSpec extends ZIOSpecDefault {
                       )
                     )
         error <- client(stubBackend(responses, requests)).send(GenerateContentRequest("hi"), functions).flip
-      } yield assertTrue(error.getMessage == "Unknown function: unknown_fn")
+      } yield assertTrue(
+        error == FunctionCallException.UnknownFunction("unknown_fn"),
+        error.getMessage == "Unknown function: unknown_fn",
+      )
+    },
+    test("send executes a function call that carries no thought signature") {
+      for {
+        requests <- Ref.make(Chunk.empty[String])
+        fnInputs <- Ref.make(Chunk.empty[City])
+        responses = Chunk(
+                      functionCallResponseWithoutSignature("get_weather", Json.writeToJson(City("Tokyo"))),
+                      textResponse("It is sunny."),
+                    )
+        functions = Map(
+                      "get_weather" -> FunctionDeclaration(
+                        function = (c: City) => fnInputs.update(_ :+ c).as(WeatherResult(22, "celsius", "Sunny")),
+                        description = None,
+                      )
+                    )
+        res          <- client(stubBackend(responses, requests)).send(GenerateContentRequest("weather?"), functions)
+        sentRequests <- requests.get
+        calledWith   <- fnInputs.get
+      } yield assertTrue(
+        res.text == "It is sunny.",
+        calledWith == Chunk(City("Tokyo")),
+        sentRequests.size == 2,
+      )
     },
     test("send executes multiple function calls returned in a single turn") {
       for {

--- a/zio-gcp-aiplatform/shared/src/test/scala/com/anymindgroup/gcp/aiplatform/ExpressModelClientSpec.scala
+++ b/zio-gcp-aiplatform/shared/src/test/scala/com/anymindgroup/gcp/aiplatform/ExpressModelClientSpec.scala
@@ -1,0 +1,262 @@
+package com.anymindgroup.gcp.aiplatform
+
+import com.anymindgroup.gcp.aiplatform.v1.schemas.*
+import com.anymindgroup.jsoniter.Json
+import com.github.plokhotnyuk.jsoniter_scala.core.*
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+import sttp.client4.testing.{BackendStub, ResponseStub}
+import sttp.client4.impl.zio.RIOMonadAsyncError
+import sttp.client4.{Backend, StringBody}
+import sttp.model.StatusCode
+
+import zio.schema.*
+import zio.test.*
+import zio.{Chunk, Ref, Task, ZIO}
+
+object ExpressModelClientSpec extends ZIOSpecDefault {
+
+  // input/output types for the stubbed functions
+  case class City(name: String) derives Schema
+  given JsonValueCodec[City] = JsonCodecMaker.make
+  case class WeatherResult(temperature: Int, unit: String, conditions: String) derives Schema
+  given JsonValueCodec[WeatherResult] = JsonCodecMaker.make
+  case class TimeZone(zone: String) derives Schema
+  given JsonValueCodec[TimeZone] = JsonCodecMaker.make
+  case class TimeResult(time: String) derives Schema
+  given JsonValueCodec[TimeResult] = JsonCodecMaker.make
+
+  // builds a response with a single text part
+  private def textResponse(text: String): String =
+    GoogleCloudAiplatformV1GenerateContentResponse(
+      candidates = Some(
+        Chunk(
+          GoogleCloudAiplatformV1Candidate(
+            content = Some(
+              GoogleCloudAiplatformV1Content(
+                parts = Chunk(GoogleCloudAiplatformV1Part(text = Some(text))),
+                role = Some("model"),
+              )
+            )
+          )
+        )
+      )
+    ).toJsonString
+
+  // builds a response with one candidate holding one function call part per provided call.
+  // a thoughtSignature must be present for the client to pick up the function call.
+  private def functionCallResponse(calls: (String, Json, String)*): String =
+    GoogleCloudAiplatformV1GenerateContentResponse(
+      candidates = Some(
+        Chunk(
+          GoogleCloudAiplatformV1Candidate(
+            content = Some(
+              GoogleCloudAiplatformV1Content(
+                parts = Chunk.fromIterable(calls.map { case (name, args, signature) =>
+                  GoogleCloudAiplatformV1Part(
+                    functionCall = Some(GoogleCloudAiplatformV1FunctionCall(name = Some(name), args = Some(args))),
+                    thoughtSignature = Some(signature),
+                  )
+                }),
+                role = Some("model"),
+              )
+            )
+          )
+        )
+      )
+    ).toJsonString
+
+  // stub http backend that replies to the :generateContent endpoint with the n-th response
+  // for the n-th request, recording every request body it received.
+  private def stubBackend(responses: Chunk[String], requests: Ref[Chunk[String]]): Backend[Task] =
+    BackendStub[Task](new RIOMonadAsyncError[Any])
+      .whenRequestMatches(_.uri.pathToString.endsWith(":generateContent"))
+      .thenRespondF { req =>
+        val body = req.body match {
+          case StringBody(s, _, _) => s
+          case _                   => ""
+        }
+        requests
+          .modify(prev => (prev.size, prev :+ body))
+          .map(idx => ResponseStub.adjust(responses.lift(idx).getOrElse(responses.last), StatusCode.Ok))
+      }
+
+  private def client(backend: Backend[Task]): ExpressModelClient =
+    ExpressModelClient(
+      backend = backend,
+      projectsId = "test-project",
+      locationsId = "global",
+      publishersId = "google",
+      modelsId = "gemini-test",
+    )
+
+  private val requestCodec: JsonValueCodec[GoogleCloudAiplatformV1GenerateContentRequest] = summon
+
+  def spec = suite("ExpressModelClientSpec")(
+    test("send executes a provided function and returns the final text response") {
+      for {
+        requests <- Ref.make(Chunk.empty[String])
+        fnInputs <- Ref.make(Chunk.empty[City])
+        responses = Chunk(
+                      functionCallResponse(("get_weather", Json.writeToJson(City("Tokyo")), "sig-weather")),
+                      textResponse("The weather in Tokyo is sunny, 22°C."),
+                    )
+        functions = Map(
+                      "get_weather" -> FunctionDeclaration(
+                        function = (c: City) => fnInputs.update(_ :+ c).as(WeatherResult(22, "celsius", "Sunny")),
+                        description = Some("Get the current weather for a given city"),
+                      )
+                    )
+        res <- client(stubBackend(responses, requests)).send(
+                 GenerateContentRequest("What is the weather like in Tokyo?"),
+                 functions,
+               )
+        sentRequests <- requests.get
+        calledWith   <- fnInputs.get
+      } yield assertTrue(
+        res.text == "The weather in Tokyo is sunny, 22°C.",
+        calledWith == Chunk(City("Tokyo")),
+        sentRequests.size == 2,
+      )
+    },
+    test("send attaches the function declarations as tools on the request") {
+      for {
+        requests <- Ref.make(Chunk.empty[String])
+        responses = Chunk(textResponse("done"))
+        functions = Map(
+                      "get_weather" -> FunctionDeclaration(
+                        function = (_: City) => ZIO.succeed(WeatherResult(0, "celsius", "")),
+                        description = Some("Get the current weather for a given city"),
+                      )
+                    )
+        _            <- client(stubBackend(responses, requests)).send(GenerateContentRequest("hi"), functions)
+        sentRequests <- requests.get
+        firstReq      = readFromString(sentRequests.head)(using requestCodec)
+        declarations  = firstReq.tools
+                         .getOrElse(Chunk.empty)
+                         .flatMap(_.functionDeclarations.getOrElse(Chunk.empty))
+      } yield assertTrue(
+        declarations.map(_.name) == Chunk("get_weather"),
+        declarations.head.description == Some("Get the current weather for a given city"),
+        declarations.head.parameters.flatMap(_.`type`) == Some(GoogleCloudAiplatformV1Schema.Type.OBJECT),
+      )
+    },
+    test("send echoes the function call and its response back to the model on the next request") {
+      for {
+        requests <- Ref.make(Chunk.empty[String])
+        fnInputs <- Ref.make(Chunk.empty[City])
+        responses = Chunk(
+                      functionCallResponse(("get_weather", Json.writeToJson(City("Osaka")), "sig-1")),
+                      textResponse("It is rainy."),
+                    )
+        functions = Map(
+                      "get_weather" -> FunctionDeclaration(
+                        function = (c: City) => fnInputs.update(_ :+ c).as(WeatherResult(18, "celsius", "Rainy")),
+                        description = None,
+                      )
+                    )
+        _            <- client(stubBackend(responses, requests)).send(GenerateContentRequest("weather?"), functions)
+        sentRequests <- requests.get
+        secondReq     = readFromString(sentRequests(1))(using requestCodec)
+        parts         = secondReq.contents.flatMap(_.parts)
+      } yield assertTrue(
+        // the model's function call is echoed back with its thought signature
+        parts.exists(p => p.functionCall.flatMap(_.name) == Some("get_weather") && p.thoughtSignature == Some("sig-1")),
+        // the executed function result is sent back as a function response
+        parts.exists(_.functionResponse.exists(_.name == "get_weather")),
+      )
+    },
+    test("send returns the text response directly when the model requests no function call") {
+      for {
+        requests <- Ref.make(Chunk.empty[String])
+        fnInputs <- Ref.make(Chunk.empty[City])
+        responses = Chunk(textResponse("No tools needed here."))
+        functions = Map(
+                      "get_weather" -> FunctionDeclaration(
+                        function = (c: City) => fnInputs.update(_ :+ c).as(WeatherResult(0, "celsius", "")),
+                        description = None,
+                      )
+                    )
+        res          <- client(stubBackend(responses, requests)).send(GenerateContentRequest("hello"), functions)
+        sentRequests <- requests.get
+        calledWith   <- fnInputs.get
+      } yield assertTrue(
+        res.text == "No tools needed here.",
+        calledWith.isEmpty,
+        sentRequests.size == 1,
+      )
+    },
+    test("send fails when the model requests an unknown function") {
+      for {
+        requests <- Ref.make(Chunk.empty[String])
+        responses = Chunk(functionCallResponse(("unknown_fn", Json.writeToJson(City("Tokyo")), "sig")))
+        functions = Map(
+                      "get_weather" -> FunctionDeclaration(
+                        function = (_: City) => ZIO.succeed(WeatherResult(0, "celsius", "")),
+                        description = None,
+                      )
+                    )
+        error <- client(stubBackend(responses, requests)).send(GenerateContentRequest("hi"), functions).flip
+      } yield assertTrue(error.getMessage == "Unknown function: unknown_fn")
+    },
+    test("send executes multiple function calls returned in a single turn") {
+      for {
+        requests     <- Ref.make(Chunk.empty[String])
+        weatherCalls <- Ref.make(Chunk.empty[City])
+        timeCalls    <- Ref.make(Chunk.empty[TimeZone])
+        responses     = Chunk(
+                      functionCallResponse(
+                        ("get_weather", Json.writeToJson(City("Tokyo")), "sig-w"),
+                        ("get_time", Json.writeToJson(TimeZone("JST")), "sig-t"),
+                      ),
+                      textResponse("It is sunny at 10:00 in Tokyo."),
+                    )
+        functions = Map(
+                      "get_weather" -> FunctionDeclaration(
+                        function = (c: City) => weatherCalls.update(_ :+ c).as(WeatherResult(22, "celsius", "Sunny")),
+                        description = None,
+                      ),
+                      "get_time" -> FunctionDeclaration(
+                        function = (t: TimeZone) => timeCalls.update(_ :+ t).as(TimeResult("10:00")),
+                        description = None,
+                      ),
+                    )
+        res <- client(stubBackend(responses, requests)).send(
+                 GenerateContentRequest("weather and time in Tokyo?"),
+                 functions,
+               )
+        sentRequests <- requests.get
+        weather      <- weatherCalls.get
+        time         <- timeCalls.get
+      } yield assertTrue(
+        res.text == "It is sunny at 10:00 in Tokyo.",
+        weather == Chunk(City("Tokyo")),
+        time == Chunk(TimeZone("JST")),
+        sentRequests.size == 2,
+      )
+    },
+    test("send loops over multiple function calling turns until a text response is returned") {
+      for {
+        requests <- Ref.make(Chunk.empty[String])
+        fnInputs <- Ref.make(Chunk.empty[City])
+        responses = Chunk(
+                      functionCallResponse(("get_weather", Json.writeToJson(City("Tokyo")), "sig-1")),
+                      functionCallResponse(("get_weather", Json.writeToJson(City("Osaka")), "sig-2")),
+                      textResponse("Both cities checked."),
+                    )
+        functions = Map(
+                      "get_weather" -> FunctionDeclaration(
+                        function = (c: City) => fnInputs.update(_ :+ c).as(WeatherResult(20, "celsius", "Cloudy")),
+                        description = None,
+                      )
+                    )
+        res          <- client(stubBackend(responses, requests)).send(GenerateContentRequest("weather?"), functions)
+        sentRequests <- requests.get
+        calledWith   <- fnInputs.get
+      } yield assertTrue(
+        res.text == "Both cities checked.",
+        calledWith == Chunk(City("Tokyo"), City("Osaka")),
+        sentRequests.size == 3,
+      )
+    },
+  )
+}

--- a/zio-gcp-aiplatform/shared/src/test/scala/com/anymindgroup/gcp/aiplatform/ExpressModelClientSpec.scala
+++ b/zio-gcp-aiplatform/shared/src/test/scala/com/anymindgroup/gcp/aiplatform/ExpressModelClientSpec.scala
@@ -4,8 +4,8 @@ import com.anymindgroup.gcp.aiplatform.v1.schemas.*
 import com.anymindgroup.jsoniter.Json
 import com.github.plokhotnyuk.jsoniter_scala.core.*
 import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
-import sttp.client4.testing.{BackendStub, ResponseStub}
 import sttp.client4.impl.zio.RIOMonadAsyncError
+import sttp.client4.testing.{BackendStub, ResponseStub}
 import sttp.client4.{Backend, StringBody}
 import sttp.model.StatusCode
 


### PR DESCRIPTION
Introduces function calling support for the Vertex AI Gemini API:

- **`FunctionDeclaration[A, B]`** — a case class for defining callable functions with ZIO Schema-based input/output schemas, including JSON codec derivation
- **`withFunctions`** extension on `GenerateContentRequest` to attach function declarations as tools
- **`send(baseRequest, functions)`** overload on `ExpressModelClient` that handles the full multi-turn loop: calls declared functions when the model requests them, echoes back `thoughtSignature`, and iterates until a text response is returned
- **`generate` overloads** accepting a functions map for typed responses
- **Two examples**: low-level (`vertex_ai_function_calling`) and high-level (`express_vertex_ai_function_calling`)