### PR TITLE
Update Google API discovery specs

### DIFF
--- a/codegen/src/main/resources/pubsub_v1.json
+++ b/codegen/src/main/resources/pubsub_v1.json
@@ -1798,7 +1798,7 @@
       }
     }
   },
-  "revision": "20260712",
+  "revision": "20260716",
   "rootUrl": "https://pubsub.googleapis.com/",
   "schemas": {
     "AIInference": {
@@ -2029,7 +2029,7 @@
       "id": "BigQueryConfig",
       "properties": {
         "dropUnknownFields": {
-          "description": "Optional. When true and use_topic_schema is true, any fields that are a part of the topic schema that are not part of the BigQuery table schema are dropped when writing to BigQuery. Otherwise, the schemas must be kept in sync and any messages with extra fields are not written and remain in the subscription's backlog.",
+          "description": "Optional. If true and `use_topic_schema` is true, drops any fields that are part of the topic schema that are not part of the BigQuery table schema when writing to BigQuery. Otherwise, the schemas must be kept in sync and any messages with extra fields are not written and remain in the subscription's backlog. If true and `use_table_schema` is true, drops any fields in the message that are not part of the BigQuery table schema when writing to BigQuery. Otherwise, the write to BigQuery will fail.",
           "type": "boolean"
         },
         "serviceAccountEmail": {

--- a/codegen/src/main/resources/sheets_v4.json
+++ b/codegen/src/main/resources/sheets_v4.json
@@ -875,7 +875,7 @@
       }
     }
   },
-  "revision": "20260713",
+  "revision": "20260720",
   "rootUrl": "https://sheets.googleapis.com/",
   "schemas": {
     "AddBandingRequest": {

--- a/codegen/src/main/resources/storage_v1.json
+++ b/codegen/src/main/resources/storage_v1.json
@@ -253,7 +253,7 @@
       "location": "northamerica-south1"
     }
   ],
-  "etag": "\"3135323936363432373336323931383330383738\"",
+  "etag": "\"35383531303536383737353933333433313638\"",
   "icons": {
     "x16": "https://www.google.com/images/icons/product/cloud_storage-16.png",
     "x32": "https://www.google.com/images/icons/product/cloud_storage-32.png"
@@ -4512,7 +4512,7 @@
       }
     }
   },
-  "revision": "20260711",
+  "revision": "20260719",
   "rootUrl": "https://storage.googleapis.com/",
   "schemas": {
     "AdvanceRelocateBucketOperationRequest": {


### PR DESCRIPTION
Automated daily update of Google API discovery documents.

Updated specs:
- aiplatform v1
- bigquery v2
- iamcredentials v1
- pubsub v1
- sheets v4
- storage v1